### PR TITLE
Limit camera rotation and view

### DIFF
--- a/BlockBuilder3D
+++ b/BlockBuilder3D
@@ -33,7 +33,8 @@ public class BlockBuilder3D extends Application {
     private final double CAM_SPEED = 6.0;       // unidades por segundo (traslación)
     private final double BLOCK_SPEED = 6.0;     // unidades por segundo (bloque en modo recolocación)
     private final double MOUSE_SENS = 0.15;     // grados por píxel
-    private final double PITCH_MIN = -89, PITCH_MAX = 89;
+    private final double PITCH_MIN = -89, PITCH_MAX = -5;
+    private final double YAW_MIN = -179, YAW_MAX = 179;
 
     // ======= Estructura escena =======
     private BorderPane rootUI;
@@ -44,12 +45,11 @@ public class BlockBuilder3D extends Application {
 
     // Cámara en ejes
     private double camX = 0, camY = 6, camZ = 20;
-    private double yaw = 0, pitch = 0; // grados
+    private double yaw = 0, pitch = -30; // grados
 
     // Estado input
     private final Set<KeyCode> keys = new HashSet<>();
     private double lastMouseX = -1, lastMouseY = -1;
-    private boolean sceneHasFocus = false;
 
     // Raycast epsilon
     private final double EPS = 1e-6;
@@ -271,11 +271,8 @@ public class BlockBuilder3D extends Application {
             keys.remove(e.getCode());
         });
 
-        subScene3D.setOnMouseEntered(e -> sceneHasFocus = true);
-        subScene3D.setOnMouseExited(e -> sceneHasFocus = false);
-
-        subScene3D.setOnMouseMoved(e -> {
-            if (!sceneHasFocus || mode != Mode.CAMERA) return;
+        scene.setOnMouseMoved(e -> {
+            if (mode != Mode.CAMERA) return;
             if (lastMouseX < 0) { lastMouseX = e.getSceneX(); lastMouseY = e.getSceneY(); return; }
             double dx = e.getSceneX() - lastMouseX;
             double dy = e.getSceneY() - lastMouseY;
@@ -285,10 +282,13 @@ public class BlockBuilder3D extends Application {
             pitch -= dy * MOUSE_SENS;
             if (pitch < PITCH_MIN) pitch = PITCH_MIN;
             if (pitch > PITCH_MAX) pitch = PITCH_MAX;
+            if (yaw < YAW_MIN) yaw = YAW_MIN;
+            if (yaw > YAW_MAX) yaw = YAW_MAX;
             applyCameraTransform();
         });
+        scene.setOnMouseExited(e -> { lastMouseX = -1; lastMouseY = -1; });
 
-        subScene3D.setOnMousePressed(e -> {
+        scene.setOnMousePressed(e -> {
             if (e.getButton() == MouseButton.SECONDARY && mode == Mode.CAMERA) {
                 // Click derecho: colocar bloque donde apunta la mirilla
                 placeBlockFromCrosshair();
@@ -435,8 +435,8 @@ public class BlockBuilder3D extends Application {
         camera.setTranslateZ(camZ);
 
         camera.getTransforms().setAll(
-                new RotateX(pitch),
-                new RotateY(yaw)
+                new RotateY(yaw),
+                new RotateX(pitch)
         );
     }
 


### PR DESCRIPTION
## Summary
- Apply yaw before pitch to avoid unintended camera roll
- Keep ground grid anchored below by enforcing downward tilt

## Testing
- `javac BlockBuilder3D.java` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b87cbaf52c8320a9c5fa4b4bdc6de9