### PR TITLE
Handle SubScene mouse input for block placement

### DIFF
--- a/BlockBuilder3D.java
+++ b/BlockBuilder3D.java
@@ -158,6 +158,8 @@ public class BlockBuilder3D extends Application {
 
         subScene3D = new SubScene(worldRoot, 1280, 720, true, SceneAntialiasing.BALANCED);
         subScene3D.setCamera(camera);
+        // Allow capturing mouse events even when no 3D node is under the cursor
+        subScene3D.setPickOnBounds(true);
 
         // Fondo y capa de mirilla
         Pane crosshair = crosshairNode();
@@ -271,9 +273,13 @@ public class BlockBuilder3D extends Application {
             keys.remove(e.getCode());
         });
 
-        scene.setOnMouseMoved(e -> {
+        subScene3D.setOnMouseMoved(e -> {
             if (mode != Mode.CAMERA) return;
-            if (lastMouseX < 0) { lastMouseX = e.getSceneX(); lastMouseY = e.getSceneY(); return; }
+            if (lastMouseX < 0) {
+                lastMouseX = e.getSceneX();
+                lastMouseY = e.getSceneY();
+                return;
+            }
             double dx = e.getSceneX() - lastMouseX;
             double dy = e.getSceneY() - lastMouseY;
             lastMouseX = e.getSceneX();
@@ -286,18 +292,21 @@ public class BlockBuilder3D extends Application {
             if (yaw > YAW_MAX) yaw = YAW_MAX;
             applyCameraTransform();
         });
-        scene.setOnMouseExited(e -> { lastMouseX = -1; lastMouseY = -1; });
+        subScene3D.setOnMouseExited(e -> {
+            lastMouseX = -1;
+            lastMouseY = -1;
+        });
 
-        scene.setOnMousePressed(e -> {
+        subScene3D.setOnMousePressed(e -> {
             if (e.getButton() == MouseButton.SECONDARY && mode == Mode.CAMERA) {
                 // Click derecho: colocar bloque donde apunta la mirilla
                 placeBlockFromCrosshair();
-            } else {
+                e.consume();
+            } else if (mode == Mode.BLOCK_EDIT) {
                 // Cualquier otro click: si estamos en modo edición, volver a cámara
-                if (mode == Mode.BLOCK_EDIT) {
-                    mode = Mode.CAMERA;
-                    editingBlock = null;
-                }
+                mode = Mode.CAMERA;
+                editingBlock = null;
+                e.consume();
             }
         });
     }


### PR DESCRIPTION
## Summary
- Register mouse handlers directly on `subScene3D` to capture 3D view interactions
- Consume secondary clicks or exit block edit mode so subsequent clicks are handled
- Enable picking on subscene bounds so camera movement works even over empty space

## Testing
- `javac BlockBuilder3D.java` *(fails: package javafx.animation does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68b8d9f2d2148320ac67af52dd20b2df